### PR TITLE
Add support of apache_request_header

### DIFF
--- a/src/ApiGuardian.php
+++ b/src/ApiGuardian.php
@@ -53,11 +53,20 @@ class ApiGuardian
         /** @var Request $request */
         $request = $app->getRequest();
 
-        if (!$request->hasHeader('Authorization')) {
+        // Fix for issue #1
+        $apacheHeaders = [];
+        if (\function_exists('apache_request_headers')){
+            $apacheHeaders = apache_request_headers();
+        }
+
+        if (!isset($apacheHeaders['authorization']) && !$request->hasHeader('Authorization')) {
             throw new NoTokenProvidedException();
         }
 
-        if (!\in_array($request->getHeaderLine('Authorization'), $apiKeys, true)) {
+        $authHeader = $request->getHeaderLine('Authorization');
+        $authHeader = empty($authHeader) ? $apacheHeaders['authorization'] : $authHeader;
+
+        if (!\in_array($authHeader, $apiKeys, true)) {
             throw new InvalidTokenException();
         }
     }

--- a/src/ApiGuardian.php
+++ b/src/ApiGuardian.php
@@ -54,17 +54,17 @@ class ApiGuardian
         $request = $app->getRequest();
 
         // Fix for issue #1
-        $apacheHeaders = [];
+        $httpHeader = [];
         if (\function_exists('apache_request_headers')) {
-            $apacheHeaders = apache_request_headers();
+            $httpHeader = apache_request_headers();
         }
 
-        if (!isset($apacheHeaders['authorization']) && !$request->hasHeader('Authorization')) {
+        if (!isset($httpHeader['authorization']) && !$request->hasHeader('Authorization')) {
             throw new NoTokenProvidedException();
         }
 
         $authHeader = $request->getHeaderLine('Authorization');
-        $authHeader = empty($authHeader) ? $apacheHeaders['authorization'] : $authHeader;
+        $authHeader = empty($authHeader) ? $httpHeader['authorization'] : $authHeader;
 
         if (!\in_array($authHeader, $apiKeys, true)) {
             throw new InvalidTokenException();

--- a/src/ApiGuardian.php
+++ b/src/ApiGuardian.php
@@ -55,7 +55,7 @@ class ApiGuardian
 
         // Fix for issue #1
         $apacheHeaders = [];
-        if (\function_exists('apache_request_headers')){
+        if (\function_exists('apache_request_headers')) {
             $apacheHeaders = apache_request_headers();
         }
 


### PR DESCRIPTION
check authorization headers from the method apache_request_header() when
apache won't give the header from the $_SERVER var.